### PR TITLE
Improve http performances

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.plugin</groupId>
     <artifactId>graylog-plugin-http-output</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>
@@ -101,13 +101,24 @@
             <artifactId>okhttp</artifactId>
             <version>2.5.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.squareup.okio</groupId>
+            <artifactId>okio</artifactId>
+            <version>2.4.0</version>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.8.5</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>4.4</version>
+        </dependency>
     </dependencies>
+
 
     <build>
         <resources>

--- a/src/main/java/com/plugin/HttpOutput.java
+++ b/src/main/java/com/plugin/HttpOutput.java
@@ -5,10 +5,18 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
+import okhttp3.*;
+import okio.BufferedSink;
+import okio.GzipSink;
+import okio.Okio;
+import org.apache.commons.collections.FastArrayList;
+import org.apache.commons.collections4.ListUtils;
 import org.graylog2.plugin.Message;
 import org.graylog2.plugin.configuration.Configuration;
 import org.graylog2.plugin.configuration.ConfigurationRequest;
+import org.graylog2.plugin.configuration.fields.BooleanField;
 import org.graylog2.plugin.configuration.fields.ConfigurationField;
 import org.graylog2.plugin.configuration.fields.TextField;
 import org.graylog2.plugin.outputs.MessageOutput;
@@ -20,121 +28,188 @@ import com.google.gson.Gson;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 
-import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
-
 /**
  * This is the plugin. Your class should implement one of the existing plugin
  * interfaces. (i.e. AlarmCallback, MessageInput, MessageOutput)
  */
 public class HttpOutput implements MessageOutput {
 
-	private boolean shutdown;
-	private String url;
-	private static final String CK_OUTPUT_API = "output_api";
-	private static final Logger LOG = LoggerFactory.getLogger(HttpOutput.class);
+    public static final int HTTP_BATCH_SIZE = 500;
+    private final OkHttpClient httpClient;
+    private final Gson gson = new Gson();
+    private boolean shutdown;
+    private String url;
+    private static final String CK_OUTPUT_API = "output_api";
+    private static final String CK_GZIP_REQUEST = "gzip_request";
+    private static final Logger LOG = LoggerFactory.getLogger(HttpOutput.class);
+    private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
 
-	@Inject
-	public HttpOutput(@Assisted Stream stream, @Assisted Configuration conf) throws HttpOutputException {
+    /**
+     * This interceptor compresses the HTTP request body. Many webservers can't handle this!
+     * <p>
+     * taken from https://square.github.io/okhttp/interceptors/
+     */
+    final class GzipRequestInterceptor implements Interceptor {
+        @Override
+        public Response intercept(Interceptor.Chain chain) throws IOException {
+            Request originalRequest = chain.request();
+            if (originalRequest.body() == null || originalRequest.header("Content-Encoding") != null) {
+                return chain.proceed(originalRequest);
+            }
 
-		url = conf.getString(CK_OUTPUT_API);
-		shutdown = false;
-		LOG.info(" Http Output Plugin has been configured with the following parameters:");
-		LOG.info(CK_OUTPUT_API + " : " + url);
-		
-		try {
-            final URL urlTest = new URL(url);
+            Request compressedRequest = originalRequest.newBuilder()
+                .header("Content-Encoding", "gzip")
+                .method(originalRequest.method(), gzip(originalRequest.body()))
+                .build();
+            return chain.proceed(compressedRequest);
+        }
+
+        private RequestBody gzip(final RequestBody body) {
+            return new RequestBody() {
+                @Override
+                public MediaType contentType() {
+                    return body.contentType();
+                }
+
+                @Override
+                public long contentLength() {
+                    return -1; // We don't know the compressed length in advance!
+                }
+
+                @Override
+                public void writeTo(BufferedSink sink) throws IOException {
+                    BufferedSink gzipSink = Okio.buffer(new GzipSink(sink));
+                    body.writeTo(gzipSink);
+                    gzipSink.close();
+                }
+            };
+        }
+    }
+
+    @Inject
+    public HttpOutput(@Assisted Stream stream, @Assisted Configuration conf) throws HttpOutputException {
+
+        this.url = conf.getString(CK_OUTPUT_API);
+
+        this.shutdown = false;
+        LOG.info(" Http Output Plugin has been configured with the following parameters:");
+        LOG.info(CK_OUTPUT_API + " : " + this.url);
+        LOG.info(CK_GZIP_REQUEST + " : " + conf.getBoolean(CK_GZIP_REQUEST));
+
+        try {
+            new URL(this.url);
         } catch (MalformedURLException e) {
-        	LOG.info("Error in the given API", e);
+            LOG.info("Error in the given API", e);
             throw new HttpOutputException("Error while constructing the API.", e);
         }
-	}
 
-	@Override
-	public boolean isRunning() {
-		return !shutdown;
-	}
+        OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder()
+            .connectTimeout(10, TimeUnit.SECONDS)
+            .writeTimeout(10, TimeUnit.SECONDS)
+            .readTimeout(5, TimeUnit.SECONDS);
 
-	@Override
-	public void stop() {
-		shutdown = true;
+        if (conf.getBoolean(CK_GZIP_REQUEST)) {
+            clientBuilder.addInterceptor(new GzipRequestInterceptor());
+        }
+        this.httpClient = clientBuilder.build();
+    }
 
-	}
+    @Override
+    public boolean isRunning() {
+        return !this.shutdown;
+    }
 
-	@Override
-	public void write(List<Message> msgs) throws Exception {
-		for (Message msg : msgs) {
-			writeBuffer(msg.getFields());
-		}
-	}
+    @Override
+    public void stop() {
+        this.shutdown = true;
 
-	@Override
-	public void write(Message msg) throws Exception {
-		if (shutdown) {
-			return;
-		}
+    }
 
-		writeBuffer(msg.getFields());
-	}
+    @Override
+    public void write(List<Message> msgs) throws Exception {
 
-	public void writeBuffer(Map<String, Object> data) throws HttpOutputException {
-		OkHttpClient client = new OkHttpClient();
-		Gson gson = new Gson();
+        for (List<Message> partition : ListUtils.partition(msgs, HTTP_BATCH_SIZE)) {
+            List<Map<String, Object>> payload = new FastArrayList();
+            for (Message msg : partition) {
+                payload.add(msg.getFields());
+            }
+            this.executeRequest(RequestBody.create(
+                                                   JSON,
+                                                   this.gson.toJson(payload)
+                                                   ));
+        }
 
-		try {
-			final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
+    }
 
-			RequestBody body = RequestBody.create(JSON, gson.toJson(data));
-			Request request = new Request.Builder().url(url).post(body).build();
-			Response response = client.newCall(request).execute();
-			response.close();
-			if (response.code() != 200) {
-				LOG.info("Unexpected HTTP response status " + response.code());
-				throw new HttpOutputException("Unexpected HTTP response status " + response.code());
-			}
-		} catch (IOException e) {
-			LOG.info("Error while posting the stream data to the given API", e);
-            throw new HttpOutputException("Error while posting stream to HTTP.", e);
-		}
+    @Override
+    public void write(Message msg) throws Exception {
 
-	}
+        this.executeRequest(
+                            RequestBody.create(
+                                               JSON,
+                                               this.gson.toJson(msg.getFields())
+                                               )
+                            );
+    }
 
-	public interface Factory extends MessageOutput.Factory<HttpOutput> {
-		@Override
-		HttpOutput create(Stream stream, Configuration configuration);
+    private void executeRequest(RequestBody requestBody) throws HttpOutputException, IOException {
+        if (this.shutdown) {
+            return;
+        }
 
-		@Override
-		Config getConfig();
+        Request request = new Request.Builder()
+            .url(this.url)
+            .post(requestBody)
+            .build();
 
-		@Override
-		Descriptor getDescriptor();
-	}
+        // ensure the response (and underlying response body) is closed
+        try (Response response = this.httpClient.newCall(request).execute()) {
+            if (response.code() != 200) {
+                LOG.info("Unexpected HTTP response status " + response.code());
+                throw new HttpOutputException("Unexpected HTTP response status " + response.code());
+            }
+        }
+    }
 
-	public static class Descriptor extends MessageOutput.Descriptor {
-		public Descriptor() {
-			super("HttpOutput Output", false, "", "Forwards stream to HTTP.");
-		}
-	}
 
-	public static class Config extends MessageOutput.Config {
-		@Override
-		public ConfigurationRequest getRequestedConfiguration() {
-			final ConfigurationRequest configurationRequest = new ConfigurationRequest();
-			configurationRequest.addField(new TextField(CK_OUTPUT_API, "API to forward the stream data.", "/",
-					"HTTP address where the stream data to be sent.", ConfigurationField.Optional.NOT_OPTIONAL));
+    public interface Factory extends MessageOutput.Factory<HttpOutput> {
+        @Override
+        HttpOutput create(Stream stream, Configuration configuration);
 
-			return configurationRequest;
-		}
-	}
+        @Override
+        Config getConfig();
 
-	public class HttpOutputException extends Exception {
+        @Override
+        Descriptor getDescriptor();
+    }
 
-		private static final long serialVersionUID = -5301266791901423492L;
+    public static class Descriptor extends MessageOutput.Descriptor {
+        public Descriptor() {
+            super("HttpOutput Output", false, "", "Forwards stream to HTTP.");
+        }
+    }
 
-		public HttpOutputException(String msg) {
+    public static class Config extends MessageOutput.Config {
+        @Override
+        public ConfigurationRequest getRequestedConfiguration() {
+            final ConfigurationRequest configurationRequest = new ConfigurationRequest();
+
+            configurationRequest.addField(
+                                          new TextField(CK_OUTPUT_API, "API to forward the stream data.", "/",
+                                                        "HTTP address where the stream data to be sent.", ConfigurationField.Optional.NOT_OPTIONAL));
+
+            configurationRequest.addField(new BooleanField(CK_GZIP_REQUEST, "GZIP request", false,
+                                                           "Enable GZIP compression for HTTP requests."));
+
+            return configurationRequest;
+        }
+    }
+
+    public class HttpOutputException extends Exception {
+
+        private static final long serialVersionUID = -5301266791901423492L;
+
+        public HttpOutputException(String msg) {
             super(msg);
         }
 


### PR DESCRIPTION
This PR includes the following improvments:

- Connection reuse. As specified in `okhttp` documentation, a connection pool can be leveraged if a single client is used across all the queries.  
- gzip request compression. A dedicated interception is implemented to compress the JSON payload before emission. One can note, the compression code is borrowed from the official documentation of the http library. HTTP request compression is not supported by every web servers thus a configuration parameter is added to the plugin to enable or disable this feature from the web interface.
- batch mode. When multiple output messages must be sent by the plugin, they are sent in batches of 500 messages under the same JSON array.