### PR TITLE
GraylogHttpOutput: fix the plugin to be able to push on SEKOIA.Io HTTP Intake

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.plugin</groupId>
     <artifactId>graylog-plugin-http-output</artifactId>
-    <version>1.0.3</version>
+    <version>1.0.4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>
@@ -36,7 +36,7 @@
         <connection>scm:git:git@github.com:SekoiaLab/graylog-http-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:SekoiaLab/graylog-http-plugin.git</developerConnection>
         <url>https://github.com/SekoiaLab/graylog-http-plugin</url>
-        <tag>1.0.3</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.plugin</groupId>
     <artifactId>graylog-plugin-http-output</artifactId>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>1.0.3</version>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>
@@ -36,7 +36,7 @@
         <connection>scm:git:git@github.com:SekoiaLab/graylog-http-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:SekoiaLab/graylog-http-plugin.git</developerConnection>
         <url>https://github.com/SekoiaLab/graylog-http-plugin</url>
-        <tag>HEAD</tag>
+        <tag>1.0.3</tag>
     </scm>
 
     <properties>


### PR DESCRIPTION
Fix the payload sent to the HTTP Intake of SEKOIA.IO.

Remove the option to send Gzipped payload as the HTTP intake doesn't currently support Gzipped content.

CARE request.