### PR TITLE
fix(GraylogHTTPPlugin): send 'full_message' when the field exists

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.plugin</groupId>
     <artifactId>graylog-plugin-http-output</artifactId>
-    <version>1.0.6-SNAPSHOT</version>
+    <version>1.0.5-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>
@@ -30,16 +30,12 @@
             <name>SekoiaLab</name>
             <email>contact@sekoia.io</email>
         </developer>
-	<developer>
-	    <name>Maxence FOSSAT</name>
-	    <email>maxence.fossat@protonmail.com</email>
-	</developer>
     </developers>
 
     <scm>
-        <connection>scm:git:git@github.com:alletrof/graylog-http-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:alletrof/graylog-http-plugin.git</developerConnection>
-        <url>https://github.com/alletrof/graylog-http-plugin</url>
+        <connection>scm:git:git@github.com:SekoiaLab/graylog-http-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com:SekoiaLab/graylog-http-plugin.git</developerConnection>
+        <url>https://github.com/SekoiaLab/graylog-http-plugin</url>
         <tag>HEAD</tag>
     </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.plugin</groupId>
     <artifactId>graylog-plugin-http-output</artifactId>
-    <version>1.0.5-SNAPSHOT</version>
+    <version>1.0.5</version>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>
@@ -30,12 +30,16 @@
             <name>SekoiaLab</name>
             <email>contact@sekoia.io</email>
         </developer>
+	<developer>
+	    <name>Maxence FOSSAT</name>
+	    <email>maxence.fossat@protonmail.com</email>
+	</developer>
     </developers>
 
     <scm>
-        <connection>scm:git:git@github.com:SekoiaLab/graylog-http-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:SekoiaLab/graylog-http-plugin.git</developerConnection>
-        <url>https://github.com/SekoiaLab/graylog-http-plugin</url>
+        <connection>scm:git:git@github.com:alletrof/graylog-http-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com:alletrof/graylog-http-plugin.git</developerConnection>
+        <url>https://github.com/alletrof/graylog-http-plugin</url>
         <tag>HEAD</tag>
     </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>com.plugin</groupId>
     <artifactId>graylog-plugin-http-output</artifactId>
-    <version>1.0.5</version>
+    <version>1.0.6-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>

--- a/src/main/java/com/plugin/HttpOutput.java
+++ b/src/main/java/com/plugin/HttpOutput.java
@@ -98,7 +98,12 @@ public class HttpOutput implements MessageOutput {
 
         Map<String, Object> payload = new HashMap<>();
         payload.put("intake_key", this.intake_key);
-        payload.put("json", msg.getMessage());
+	if (msg.hasField("full_message")) {
+	    payload.put("json", msg.getFieldAs(String.class, "full_message"));
+	}
+	else {
+            payload.put("json", msg.getMessage());
+	}
 
         this.executeRequest(
                             RequestBody.create(


### PR DESCRIPTION
Using the `hasField()` and `getFieldAs()` method from the `org.graylog2.plugin.Message` object, we can send the `full_message` instead of the `message` from a GELF Input. This helps in adding compatibility for NXLog messages ingested in GELF format while maintaining compatibility for traditional log formats using the `message` field.